### PR TITLE
Add `st.cache` to load model

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,8 +10,16 @@ st.set_page_config(
     initial_sidebar_state="expanded", )
 
 
+@st.cache(allow_output_mutation=True)
+def load_model():
+    tokenizer = AutoTokenizer.from_pretrained("gagan3012/keytotext-small")
+    model = AutoModelWithLMHead.from_pretrained("gagan3012/keytotext-small")
+    return tokenizer, model
+
+
 @st.cache(suppress_st_warning=True, ttl=1000)
 def generate(keywords, temp, top_p):
+    tokenizer, model = load_model()
     tokenizer = AutoTokenizer.from_pretrained("gagan3012/keytotext-small")
     model = AutoModelWithLMHead.from_pretrained("gagan3012/keytotext-small")
     text = str(keywords)


### PR DESCRIPTION
Hi @gagan3012,

Johannes from the Streamlit team here :) I am currently investigating why apps run over the resource limits of Streamlit Sharing and saw that your app was affected in the past few days. 

Thought I'd send you a small PR which should fix this. You've already been on a good way with using `st.cache` but it gets even better if you use it once more to load the model. This makes sure the model and tokenizer are only loaded once, which should make the app consume less memory (and not run into resource limits again! Plus, I've seen that it also works a bit faster now ;). 

Hope this works for you and let me know if you have any other questions! 🎈

Cheers, Johannes