### PR TITLE
Update trainer.py

### DIFF
--- a/keytotext/pipeline.py
+++ b/keytotext/pipeline.py
@@ -32,6 +32,12 @@ SUPPORTED_TASKS = {
             "model": "gagan3012/k2t-new",
         },
     },
+    "anath/T5key2textcomgenminime": {
+        "impl": NMPipeline,
+        "default": {
+            "model": "anath/T5key2textcomgenminime",
+        },
+    },
 }
 
 

--- a/keytotext/trainer.py
+++ b/keytotext/trainer.py
@@ -318,13 +318,12 @@ class trainer:
         )
 
         gpus = -1 if use_gpu else 0
-
+#delete  progress_bar_refresh_rate=5,since this keyword argument is no longer supported by latest version (1.7.0) of pytorch.Lightning.Trainer module
         trainer = Trainer(
             logger=logger,
             callbacks=early_stop_callback,
             max_epochs=max_epochs,
-            gpus=gpus,
-            progress_bar_refresh_rate=5,
+            gpus=gpus,           
             tpu_cores=tpu_cores
         )
 


### PR DESCRIPTION
Delete progress_bar_refresh_rate in trainer.py 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
delete  progress_bar_refresh_rate=5, since this keyword argument is no longer supported by the latest version (1.7.0) of PyTorch.Lightning.Trainer module 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
having this argument fails the training process
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran key to text on the custom dataset before and after August 2nd, 2022. Changes in the new version of Pytorch Lightning's Trainer were put into effect on that date where the above argument was removed and hence, the custom training failed since that day. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
